### PR TITLE
Mention faster option if you only have points

### DIFF
--- a/GeoPython2023.ipynb
+++ b/GeoPython2023.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1145,7 +1144,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "homes = geopandas.read_file(\"data/sales.gpkg\", engine=\"pyogrio\").to_crs(\"EPSG:2926\")\n",
@@ -1201,6 +1202,51 @@
     "    numpy.asarray(homes[:1000].geometry)[:, numpy.newaxis],\n",
     "    numpy.asarray(food.geometry)[numpy.newaxis, :],\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The distance operation is inherently a costly operation (for generic geometries) if you do this for _all_ combinations. And it also results in a large result that can blow up in memory (for this example, it gives a (21613, 9595) shaped result, i.e. around 200M distance values or 1.5 GB in memory).  \n",
+    "Below, we will see some faster approaches in case you don't need all pairwise combinations.\n",
+    "\n",
+    "Specifically for Point geometries, calculating the distance using shapely gives some overhead, compared to calculating this directly on an array of coordinates. For example, for this example we could also use `scipy.spatial.distance_matrix`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "coords_homes = shapely.get_coordinates(homes.geometry)\n",
+    "coords_food = shapely.get_coordinates(food.geometry)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from scipy import spatial"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "spatial.distance_matrix(coords_homes[:1000], coords_food)"
    ]
   },
   {

--- a/GeoPython2023.ipynb
+++ b/GeoPython2023.ipynb
@@ -1253,6 +1253,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "This however only works for Points, and not for other geometry types."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Distance to nearest point\n",
     "\n",
     "> **QUESTION:** How to calculate the distance to the nearest feature of another GeoDataFrame?"


### PR DESCRIPTION
This is around 10x faster compared to using shapely (but would still take around 10s on the full dataset, compared to <1s for nearest/dwithin examples)